### PR TITLE
Workaround a NullReferenceException when working with UI EventTrigger

### DIFF
--- a/EasyEventEditor.cs
+++ b/EasyEventEditor.cs
@@ -816,7 +816,7 @@ public class EasyEventEditorDrawer : PropertyDrawer
         MethodInfo invokeMethod = InvokeFindMethod("Invoke", dummyEvent, dummyEvent, PersistentListenerMode.EventDefined);
         FieldInfo serializedField = currentProperty.serializedObject.targetObject.GetType().GetField(currentProperty.name, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
 
-        object[] invokeTargets = currentProperty.serializedObject.targetObjects.Select(target => target == null ? null : serializedField.GetValue(target)).Where(f => f != null).ToArray();
+        object[] invokeTargets = currentProperty.serializedObject.targetObjects.Select(target => target == null || serializedField == null ? null : serializedField.GetValue(target)).Where(f => f != null).ToArray();
         
         EditorGUI.BeginDisabledGroup(invokeTargets.Length == 0 || invokeMethod == null);
 


### PR DESCRIPTION
When using the EventTrigger component to assign ,e.g. PointerEnter and PointerExit events, EasyEventEditor throws an exception: The event types take in BaseEventData.

The EventTrigger component is used for example in the ExMenu prefab.

I will admit, my change is fixing the immediate exception and the Invoke button does not work. But it allows events to be seen an edited.

Might make more sense to hide the Invoke button rather than invest time into fixing it as this component is rarely used anyway.

Here is the full exception:
```NullReferenceException: Object reference not set to an instance of an object
Merlin.EasyEventEditorDrawer+<DrawInvokeField>c__AnonStorey0.<>m__0 (UnityEngine.Object target) (at Assets/Merlin/Editor/EasyEventEditor.cs:819)
System.Linq.Enumerable+<CreateSelectIterator>c__Iterator10`2[UnityEngine.Object,System.Object].MoveNext ()
System.Linq.Enumerable+<CreateWhereIterator>c__Iterator1D`1[System.Object].MoveNext ()
System.Collections.Generic.List`1[System.Object].AddEnumerable (IEnumerable`1 enumerable) (at /Users/builduser/buildslave/mono/build/mcs/class/corlib/System.Collections.Generic/List.cs:128)
System.Collections.Generic.List`1[System.Object]..ctor (IEnumerable`1 collection) (at /Users/builduser/buildslave/mono/build/mcs/class/corlib/System.Collections.Generic/List.cs:65)
System.Linq.Enumerable.ToArray[Object] (IEnumerable`1 source)
Merlin.EasyEventEditorDrawer.DrawInvokeField (Rect position, Single headerStartOffset) (at Assets/Merlin/Editor/EasyEventEditor.cs:819)
Merlin.EasyEventEditorDrawer.DrawHeaderCallback (Rect headerRect) (at Assets/Merlin/Editor/EasyEventEditor.cs:960)
UnityEditorInternal.ReorderableList.DoListHeader (Rect headerRect) (at /Users/builduser/buildslave/unity/build/Editor/Mono/GUI/ReorderableList.cs:622)
UnityEditorInternal.ReorderableList.DoList (Rect rect) (at /Users/builduser/buildslave/unity/build/Editor/Mono/GUI/ReorderableList.cs:406)
Merlin.EasyEventEditorDrawer.OnGUI (Rect position, UnityEditor.SerializedProperty property, UnityEngine.GUIContent label) (at Assets/Merlin/Editor/EasyEventEditor.cs:773)
UnityEditor.PropertyDrawer.OnGUISafe (Rect position, UnityEditor.SerializedProperty property, UnityEngine.GUIContent label) (at /Users/builduser/buildslave/unity/build/Editor/Mono/ScriptAttributeGUI/PropertyDrawer.cs:22)
UnityEditor.PropertyHandler.OnGUI (Rect position, UnityEditor.SerializedProperty property, UnityEngine.GUIContent label, Boolean includeChildren) (at /Users/builduser/buildslave/unity/build/Editor/Mono/ScriptAttributeGUI/PropertyHandler.cs:142)
UnityEditor.PropertyHandler.OnGUILayout (UnityEditor.SerializedProperty property, UnityEngine.GUIContent label, Boolean includeChildren, UnityEngine.GUILayoutOption[] options) (at /Users/builduser/buildslave/unity/build/Editor/Mono/ScriptAttributeGUI/PropertyHandler.cs:203)
UnityEditor.EditorGUILayout.PropertyField (UnityEditor.SerializedProperty property, UnityEngine.GUIContent label, Boolean includeChildren, UnityEngine.GUILayoutOption[] options) (at /Users/builduser/buildslave/unity/build/Editor/Mono/EditorGUI.cs:8116)
UnityEditor.EditorGUILayout.PropertyField (UnityEditor.SerializedProperty property, UnityEngine.GUIContent label, UnityEngine.GUILayoutOption[] options) (at /Users/builduser/buildslave/unity/build/Editor/Mono/EditorGUI.cs:8104)
UnityEditor.EventSystems.EventTriggerEditor.OnInspectorGUI () (at /Users/builduser/buildslave/unity/build/Extensions/guisystem/UnityEditor.UI/EventSystem/EventTriggerEditor.cs:50)
UnityEditor.InspectorWindow.DrawEditor (UnityEditor.Editor[] editors, Int32 editorIndex, Boolean rebuildOptimizedGUIBlock, System.Boolean& showImportedObjectBarNext, UnityEngine.Rect& importedObjectBarRect) (at /Users/builduser/buildslave/unity/build/Editor/Mono/Inspector/InspectorWindow.cs:1253)
UnityEngine.GUIUtility:ProcessEvent(Int32, IntPtr)
```